### PR TITLE
6.x branch laravel 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - php: 7.3
     - php: 7.4
-    - php: nightly
   allow_failures:
     - php: nightly
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 7.2.5
     - php: 7.3
     - php: 7.4
     - php: nightly

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Versions
 ========
  - Laravel 5.3-6.* use `v4.*`
  - Laravel 7.* use `v5.*`
+ - Laravel 8.* use `v6.*`
 
 Installation
 ============

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
-        "illuminate/support": "^7.0"
+        "php": "^7.3",
+        "illuminate/support": "^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -24,9 +24,9 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^8.4|^9.0",
-        "illuminate/database": "^7.0",
-        "illuminate/filesystem": "^7.0"
+        "phpunit/phpunit": "^9.3",
+        "illuminate/database": "^8.0",
+        "illuminate/filesystem": "^8.0"
     },
     "extra": {
         "laravel": {

--- a/tests/MigrationCreatorTest.php
+++ b/tests/MigrationCreatorTest.php
@@ -19,14 +19,16 @@ class DatabaseMigrationCreatorTest extends TestCase
     {
         $creator = $this->getCreator();
 
+        $date = date('Y').'/'.date('m');
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.stub')->andReturn(false);
         $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.stub')->andReturn('DummyClass');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/2020/03')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/'.$date)->andReturn(false);
         $creator->getFilesystem()->shouldReceive('makeDirectory')->once();
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/2020/03/foo_create_bar.php', 'CreateBar');
-        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/2020/03/*.php')->andReturn(['foo/2020/03/foo_create_bar.php']);
-        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/2020/03/foo_create_bar.php');
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/'.$date.'/foo_create_bar.php', 'CreateBar');
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/'.$date.'/*.php')->andReturn(['foo/'.$date.'/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/'.$date.'/foo_create_bar.php');
 
         $creator->create('create_bar', 'foo');
     }
@@ -40,15 +42,16 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->afterCreate(function ($table) {
             $_SERVER['__migration.creator'] = $table;
         });
-
+        $date = date('Y').'/'.date('m');
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
         $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('DummyClass DummyTable');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/2020/03')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/' . $date)->andReturn(false);
         $creator->getFilesystem()->shouldReceive('makeDirectory')->once();
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/2020/03/foo_create_bar.php', 'CreateBar baz');
-        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/2020/03/*.php')->andReturn(['foo/2020/03/foo_create_bar.php']);
-        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/2020/03/foo_create_bar.php');
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/'.$date.'/foo_create_bar.php', 'CreateBar baz');
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/'.$date.'/*.php')->andReturn(['foo/'.$date.'/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/'.$date.'/foo_create_bar.php');
 
         $creator->create('create_bar', 'foo', $table);
 
@@ -60,14 +63,16 @@ class DatabaseMigrationCreatorTest extends TestCase
     public function testTableUpdateMigrationStoresMigrationFile()
     {
         $creator = $this->getCreator();
+        $date = date('Y').'/'.date('m');
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
         $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('DummyClass DummyTable');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/2020/03')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/'.$date)->andReturn(false);
         $creator->getFilesystem()->shouldReceive('makeDirectory')->once();
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/2020/03/foo_create_bar.php', 'CreateBar baz');
-        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/2020/03/*.php')->andReturn(['foo/2020/03/foo_create_bar.php']);
-        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/2020/03/foo_create_bar.php');
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/'.$date.'/foo_create_bar.php', 'CreateBar baz');
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/'.$date.'/*.php')->andReturn(['foo/'.$date.'/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/'.$date.'/foo_create_bar.php');
 
         $creator->create('create_bar', 'foo', 'baz');
     }
@@ -75,14 +80,16 @@ class DatabaseMigrationCreatorTest extends TestCase
     public function testTableCreationMigrationStoresMigrationFile()
     {
         $creator = $this->getCreator();
+        $date = date('Y').'/'.date('m');
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
         $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.create.stub')->andReturn('DummyClass DummyTable');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/2020/03')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/'.$date)->andReturn(false);
         $creator->getFilesystem()->shouldReceive('makeDirectory')->once();
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/2020/03/foo_create_bar.php', 'CreateBar baz');
-        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/2020/03/*.php')->andReturn(['foo/2020/03/foo_create_bar.php']);
-        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/2020/03/foo_create_bar.php');
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
+        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/'.$date.'/foo_create_bar.php', 'CreateBar baz');
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/'.$date.'/*.php')->andReturn(['foo/'.$date.'/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/'.$date.'/foo_create_bar.php');
 
         $creator->create('create_bar', 'foo', 'baz', true);
     }
@@ -93,9 +100,9 @@ class DatabaseMigrationCreatorTest extends TestCase
         $this->expectExceptionMessage('A MigrationCreatorFakeMigration class already exists.');
 
         $creator = $this->getCreator();
-
-        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/2020/03/*.php')->andReturn(['foo/2020/03/foo_create_bar.php']);
-        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/2020/03/foo_create_bar.php');
+        $date = date('Y').'/'.date('m');
+        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/'.$date.'/*.php')->andReturn(['foo/'.$date.'/foo_create_bar.php']);
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/'.$date.'/foo_create_bar.php');
 
         $creator->create('migration_creator_fake_migration', 'foo');
     }

--- a/tests/MigrationCreatorTest.php
+++ b/tests/MigrationCreatorTest.php
@@ -46,7 +46,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
         $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
         $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('DummyClass DummyTable');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/' . $date)->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/'.$date)->andReturn(false);
         $creator->getFilesystem()->shouldReceive('makeDirectory')->once();
         $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
         $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/'.$date.'/foo_create_bar.php', 'CreateBar baz');


### PR DESCRIPTION
Fresh 6.x branch to support Laravel 8
Tests fixed
Removed "nightly" build from travis.ci, because current "nightly" version of php is >8.0, which is not supported in composer.json
Closes https://github.com/JayBizzle/Laravel-Migrations-Organiser/issues/35
@JayBizzle your turn