### PR TITLE
Allowing php 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - php: 7.3
     - php: 7.4
     - php: 8.0
+    - php: 8.1
   allow_failures:
     - php: nightly
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "mockery/mockery": "^1.3.1",
         "phpunit/phpunit": "^9.3",
         "illuminate/database": "^8.0",
-        "illuminate/filesystem": "^8.0"
+        "illuminate/filesystem": "^8.0",
+        "illuminate/console": "^8.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3 <8.1",
+        "php": "^7.3|^8.0",
         "illuminate/support": "^8.0"
     },
     "autoload": {


### PR DESCRIPTION
Fixes #39

All in all, this is relatively small package, no very complicated php features are used, so it is extremely unlikely that any future 8.x release would cause issues. That's why I changed `composer.json` to just allow all next 8.x releases (in similar notation as [`illuminate/support`](https://packagist.org/packages/illuminate/support)). And when 8.2, 8.3 ... comes out, someone would only need to add it to Travis, but in the meantime at least people can just continue using it if they already moved to a next php 8 version.

I also added `illuminate/console` to the dev requirements because it wasn't there yet, causing IDE issues when you try to edit purely this package. (I guess it could be in the general requirements, but purely this package doesn't seem to need it on production ... even though probably everyone already has it there anyway.)