### PR TITLE
feat: add Laravel 11 and 12 compatibility, and update PHPUnit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,4 @@ jobs:
 
       - name: Run Unit tests
         run: |
-          vendor/bin/phpunit --coverage-clover=tests/logs/clover.xml
+          vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
+        php: [8.2, 8.3, 8.4]
 
     name: PHP:${{ matrix.php }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Versions
  - Laravel 5.3-6.* use `v4.*`
  - Laravel 7.* use `v5.*`
  - Laravel 8, 9, 10 use `v6.*`
+ - Laravel 11, 12 use `v7.*`
 
 Installation
 ============

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "illuminate/support": "^8.0|^9.0|^10.0"
+        "php": "^7.3|^8.0|^8.2",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {
@@ -40,10 +40,10 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^9.3",
-        "illuminate/database": "^8.0|^10.0",
-        "illuminate/filesystem": "^8.0|^10.0",
-        "illuminate/console": "^8.0|^10.0"
+        "phpunit/phpunit": "^9.3|^10.0|^11.0",
+        "illuminate/database": "^8.0|^10.0|^12.0",
+        "illuminate/filesystem": "^8.0|^10.0|^12.0",
+        "illuminate/console": "^8.0|^10.0|^12.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0|^8.2",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "php": "^8.2",
+        "illuminate/support": "^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {
@@ -41,9 +41,9 @@
     "require-dev": {
         "mockery/mockery": "^1.3.1",
         "phpunit/phpunit": "^9.3|^10.0|^11.0",
-        "illuminate/database": "^8.0|^10.0|^12.0",
-        "illuminate/filesystem": "^8.0|^10.0|^12.0",
-        "illuminate/console": "^8.0|^10.0|^12.0"
+        "illuminate/database": "^10.0|^12.0",
+        "illuminate/filesystem": "^10.0|^12.0",
+        "illuminate/console": "^10.0|^12.0"
     },
     "extra": {
         "laravel": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="phpunit.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="phpunit.php"
+         colors="true" stopOnFailure="false" cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/MigrationCreatorTest.php
+++ b/tests/MigrationCreatorTest.php
@@ -178,4 +178,5 @@ class MigrationCreatorTest extends TestCase
     {
         return version_compare($this->packageVersion, '9', '<');
     }
+
 }

--- a/tests/MigrationCreatorTest.php
+++ b/tests/MigrationCreatorTest.php
@@ -14,7 +14,7 @@ class MigrationCreatorTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    private $packageVersion;
+    private string $packageVersion;
 
     protected function setUp(): void
     {
@@ -22,7 +22,7 @@ class MigrationCreatorTest extends TestCase
         $this->packageVersion = substr(InstalledVersions::getVersionRanges('illuminate/database'), 1);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }
@@ -30,115 +30,152 @@ class MigrationCreatorTest extends TestCase
     public function testBasicCreateMethodStoresMigrationFile()
     {
         $creator = $this->getCreator();
+        $date = $this->currentDate();
 
-        $date = date('Y').'/'.date('m');
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.stub')->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.stub')->andReturn('DummyClass');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/'.$date)->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('makeDirectory')->once();
-        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
-        $expectedStub = $this->expectClassNameReplace() ? 'CreateBar' : 'DummyClass';
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/'.$date.'/foo_create_bar.php', $expectedStub);
-        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/'.$date.'/*.php')->andReturn(['foo/'.$date.'/foo_create_bar.php']);
-        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/'.$date.'/foo_create_bar.php');
+        $this->mockFilesystem($creator, 'migration.stub', 'DummyClass', $date);
+
+        $expectedStub = $this->replacesStubClassName() ? 'CreateBar' : 'DummyClass';
+        $creator->getFilesystem()->shouldReceive('put')->once()->with("foo/$date/foo_create_bar.php", $expectedStub);
+
+        $this->mockPostWriteFilesystem($creator, $date);
 
         $creator->create('create_bar', 'foo');
     }
 
-    public function testBasicCreateMethodCallsPostCreateHooks()
+    public function testPostCreateHooksAreCalled()
     {
+        $creator = $this->getCreator();
+        $date = $this->currentDate();
         $table = 'baz';
 
-        $creator = $this->getCreator();
         unset($_SERVER['__migration.creator']);
+
         $creator->afterCreate(function ($table) {
             $_SERVER['__migration.creator'] = $table;
         });
-        $date = date('Y').'/'.date('m');
+
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('DummyClass DummyTable');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/'.$date)->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('makeDirectory')->once();
-        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
-        $expectedStub = $this->expectClassNameReplace() ? 'CreateBar baz' : 'DummyClass baz';
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/'.$date.'/foo_create_bar.php', $expectedStub);
-        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/'.$date.'/*.php')->andReturn(['foo/'.$date.'/foo_create_bar.php']);
-        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/'.$date.'/foo_create_bar.php');
+        $this->mockFilesystem($creator, 'migration.update.stub', 'DummyClass DummyTable', $date);
+
+        $expectedStub = $this->replacesStubClassName() ? 'CreateBar baz' : 'DummyClass baz';
+        $creator->getFilesystem()->shouldReceive('put')->once()->with("foo/$date/foo_create_bar.php", $expectedStub);
+
+        $this->mockPostWriteFilesystem($creator, $date);
 
         $creator->create('create_bar', 'foo', $table);
 
-        $this->assertEquals($_SERVER['__migration.creator'], $table);
-
+        $this->assertEquals($table, $_SERVER['__migration.creator']);
         unset($_SERVER['__migration.creator']);
     }
 
-    public function testTableUpdateMigrationStoresMigrationFile()
+    public function testTableUpdateMigrationStoresFile()
     {
         $creator = $this->getCreator();
-        $date = date('Y').'/'.date('m');
+        $date = $this->currentDate();
+
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('DummyClass DummyTable');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/'.$date)->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('makeDirectory')->once();
-        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
-        $expectedStub = $this->expectClassNameReplace() ? 'CreateBar baz' : 'DummyClass baz';
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/'.$date.'/foo_create_bar.php', $expectedStub);
-        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/'.$date.'/*.php')->andReturn(['foo/'.$date.'/foo_create_bar.php']);
-        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/'.$date.'/foo_create_bar.php');
+        $this->mockFilesystem($creator, 'migration.update.stub', 'DummyClass DummyTable', $date);
+
+        $expectedStub = $this->replacesStubClassName() ? 'CreateBar baz' : 'DummyClass baz';
+        $creator->getFilesystem()->shouldReceive('put')->once()->with("foo/$date/foo_create_bar.php", $expectedStub);
+
+        $this->mockPostWriteFilesystem($creator, $date);
 
         $creator->create('create_bar', 'foo', 'baz');
     }
 
-    public function testTableCreationMigrationStoresMigrationFile()
+    public function testTableCreationMigrationStoresFile()
     {
         $creator = $this->getCreator();
-        $date = date('Y').'/'.date('m');
+        $date = $this->currentDate();
+
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.create.stub')->andReturn('DummyClass DummyTable');
-        $creator->getFilesystem()->shouldReceive('exists')->once()->with('foo/'.$date)->andReturn(false);
-        $creator->getFilesystem()->shouldReceive('makeDirectory')->once();
-        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
-        $expectedStub = $this->expectClassNameReplace() ? 'CreateBar baz' : 'DummyClass baz';
-        $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/'.$date.'/foo_create_bar.php', $expectedStub);
-        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/'.$date.'/*.php')->andReturn(['foo/'.$date.'/foo_create_bar.php']);
-        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/'.$date.'/foo_create_bar.php');
+        $this->mockFilesystem($creator, 'migration.create.stub', 'DummyClass DummyTable', $date);
+
+        $expectedStub = $this->replacesStubClassName() ? 'CreateBar baz' : 'DummyClass baz';
+        $creator->getFilesystem()->shouldReceive('put')->once()->with("foo/$date/foo_create_bar.php", $expectedStub);
+
+        $this->mockPostWriteFilesystem($creator, $date);
 
         $creator->create('create_bar', 'foo', 'baz', true);
     }
 
-    public function testTableUpdateMigrationWontCreateDuplicateClass()
+    public function testThrowsWhenDuplicateMigrationClassExists()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('A MigrationCreatorFakeMigration class already exists.');
 
         $creator = $this->getCreator();
-        $date = date('Y').'/'.date('m');
-        $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/'.$date.'/*.php')->andReturn(['foo/'.$date.'/foo_create_bar.php']);
-        $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/'.$date.'/foo_create_bar.php');
+        $date = $this->currentDate();
+
+        $creator->getFilesystem()->shouldReceive('exists')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->andReturn('MigrationCreatorFakeMigration');
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
+        $creator->getFilesystem()->shouldReceive('makeDirectory')->andReturnTrue();
+        $creator->getFilesystem()->shouldReceive('put')->andReturn(true);
+
+        $stubPath = __DIR__ . '/stubs/MigrationCreatorFakeMigration.php';
+
+        $creator->getFilesystem()->shouldReceive('glob')->once()
+            ->with("foo/$date/*.php")
+            ->andReturn([$stubPath]);
+
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()
+            ->with($stubPath)
+            ->andReturnUsing(fn() => require_once $stubPath);
 
         $creator->create('migration_creator_fake_migration', 'foo');
     }
 
-    protected function expectClassNameReplace()
-    {
-        // Since Laravel 9.x, class name placeholders in migrations are not replaced.
-        // @see https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Migrations/MigrationCreator.php#L142
-        // @see https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Migrations/MigrationCreator.php#L139
-        return version_compare($this->packageVersion, '9', '<');
-    }
-
-    protected function getCreator()
+    protected function getCreator(): MigrationCreator
     {
         $files = Mockery::mock(Filesystem::class);
         $customStubs = 'stubs';
 
         return $this->getMockBuilder(MigrationCreator::class)
-            ->setMethods(['getDatePrefix'])
+            ->onlyMethods(['getDatePrefix'])
             ->setConstructorArgs([$files, $customStubs])
             ->getMock();
+    }
+
+    protected function mockFilesystem(MigrationCreator $creator, string $stub, string $content, string $date): void
+    {
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with("stubs/$stub")->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()
+            ->with($creator->stubPath() . "/$stub")
+            ->andReturn($content);
+
+        $creator->getFilesystem()->shouldReceive('exists')->once()
+            ->with("foo/$date")->andReturn(false);
+
+        $creator->getFilesystem()->shouldReceive('makeDirectory')->once();
+        $creator->getFilesystem()->shouldReceive('ensureDirectoryExists')->andReturn(true);
+    }
+
+    protected function mockPostWriteFilesystem(MigrationCreator $creator, string $date): void
+    {
+        $creator->getFilesystem()->shouldReceive('glob')->once()
+            ->with("foo/$date/*.php")
+            ->andReturn(["foo/$date/foo_create_bar.php"]);
+
+        $creator->getFilesystem()->shouldReceive('requireOnce')->once()
+            ->with("foo/$date/foo_create_bar.php");
+    }
+
+    protected function currentDate(): string
+    {
+        return date('Y') . '/' . date('m');
+    }
+
+    /**
+     * Laravel 8.x replaced `DummyClass` in stubs; 9.x+ leaves it untouched.
+     *
+     * @see https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Migrations/MigrationCreator.php#L142
+     * @see https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Migrations/MigrationCreator.php#L139
+     */
+    protected function replacesStubClassName(): bool
+    {
+        return version_compare($this->packageVersion, '9', '<');
     }
 }

--- a/tests/MigrationCreatorTest.php
+++ b/tests/MigrationCreatorTest.php
@@ -178,5 +178,4 @@ class MigrationCreatorTest extends TestCase
     {
         return version_compare($this->packageVersion, '9', '<');
     }
-
 }

--- a/tests/MigrationCreatorTest.php
+++ b/tests/MigrationCreatorTest.php
@@ -27,7 +27,7 @@ class MigrationCreatorTest extends TestCase
         Mockery::close();
     }
 
-    public function testBasicCreateMethodStoresMigrationFile()
+    public function test_basic_create_method_stores_migration_file()
     {
         $creator = $this->getCreator();
         $date = $this->currentDate();
@@ -43,7 +43,7 @@ class MigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo');
     }
 
-    public function testPostCreateHooksAreCalled()
+    public function test_post_create_hooks_are_called()
     {
         $creator = $this->getCreator();
         $date = $this->currentDate();
@@ -69,7 +69,7 @@ class MigrationCreatorTest extends TestCase
         unset($_SERVER['__migration.creator']);
     }
 
-    public function testTableUpdateMigrationStoresFile()
+    public function test_table_update_migration_stores_file()
     {
         $creator = $this->getCreator();
         $date = $this->currentDate();
@@ -85,7 +85,7 @@ class MigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo', 'baz');
     }
 
-    public function testTableCreationMigrationStoresFile()
+    public function test_table_creation_migration_stores_file()
     {
         $creator = $this->getCreator();
         $date = $this->currentDate();
@@ -101,7 +101,7 @@ class MigrationCreatorTest extends TestCase
         $creator->create('create_bar', 'foo', 'baz', true);
     }
 
-    public function testThrowsWhenDuplicateMigrationClassExists()
+    public function test_throws_when_duplicate_migration_class_exists()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('A MigrationCreatorFakeMigration class already exists.');
@@ -178,5 +178,4 @@ class MigrationCreatorTest extends TestCase
     {
         return version_compare($this->packageVersion, '9', '<');
     }
-
 }

--- a/tests/MigrationCreatorTest.php
+++ b/tests/MigrationCreatorTest.php
@@ -115,7 +115,7 @@ class MigrationCreatorTest extends TestCase
         $creator->getFilesystem()->shouldReceive('makeDirectory')->andReturnTrue();
         $creator->getFilesystem()->shouldReceive('put')->andReturn(true);
 
-        $stubPath = __DIR__ . '/stubs/MigrationCreatorFakeMigration.php';
+        $stubPath = __DIR__.'/stubs/MigrationCreatorFakeMigration.php';
 
         $creator->getFilesystem()->shouldReceive('glob')->once()
             ->with("foo/$date/*.php")
@@ -123,7 +123,7 @@ class MigrationCreatorTest extends TestCase
 
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()
             ->with($stubPath)
-            ->andReturnUsing(fn() => require_once $stubPath);
+            ->andReturnUsing(fn () => require_once $stubPath);
 
         $creator->create('migration_creator_fake_migration', 'foo');
     }
@@ -143,7 +143,7 @@ class MigrationCreatorTest extends TestCase
     {
         $creator->getFilesystem()->shouldReceive('exists')->once()->with("stubs/$stub")->andReturn(false);
         $creator->getFilesystem()->shouldReceive('get')->once()
-            ->with($creator->stubPath() . "/$stub")
+            ->with($creator->stubPath()."/$stub")
             ->andReturn($content);
 
         $creator->getFilesystem()->shouldReceive('exists')->once()
@@ -165,7 +165,7 @@ class MigrationCreatorTest extends TestCase
 
     protected function currentDate(): string
     {
-        return date('Y') . '/' . date('m');
+        return date('Y').'/'.date('m');
     }
 
     /**


### PR DESCRIPTION
Hi,

I've upgraded the package's compatibility to support Laravel 11 and 12.

The PHPUnit test suite has been updated accordingly, and all 5 tests are passing successfully.

Please let me know if there's anything you'd like me to adjust or improve.